### PR TITLE
fix: raise minimum_running_time_in_minutes from 2 to 30 for ephemeral runners

### DIFF
--- a/examples/ephemeral-multiarch-prebuilt/templates/runner-configs/linux-amd64-ubuntu-xl.yaml
+++ b/examples/ephemeral-multiarch-prebuilt/templates/runner-configs/linux-amd64-ubuntu-xl.yaml
@@ -34,7 +34,8 @@ runner_config:
   enable_organization_runners: true
   enable_ephemeral_runners: true
   enable_job_queued_check: true
-  minimum_running_time_in_minutes: 2
+  # See linux-amd64-ubuntu.yaml for rationale; same reasoning applies here.
+  minimum_running_time_in_minutes: 30
   enable_runner_binaries_syncer: false
   disable_runner_autoupdate: true
   create_service_linked_role_spot: true

--- a/examples/ephemeral-multiarch-prebuilt/templates/runner-configs/linux-amd64-ubuntu.yaml
+++ b/examples/ephemeral-multiarch-prebuilt/templates/runner-configs/linux-amd64-ubuntu.yaml
@@ -37,7 +37,12 @@ runner_config:
   enable_organization_runners: true
   enable_ephemeral_runners: true
   enable_job_queued_check: true
-  minimum_running_time_in_minutes: 2
+  # Must comfortably exceed the longest expected job duration. The scale-down
+  # Lambda runs every minute and terminates any runner past this threshold that
+  # GitHub's API reports as `busy: false`. For a 15+ min job, a single stale
+  # `busy: false` read (API race / cache / transient) was killing active
+  # runners mid-build and surfacing as "lost communication" on the job.
+  minimum_running_time_in_minutes: 30
   enable_runner_binaries_syncer: false
   disable_runner_autoupdate: true
   create_service_linked_role_spot: true

--- a/examples/ephemeral-multiarch-prebuilt/templates/runner-configs/linux-arm64-ubuntu.yaml
+++ b/examples/ephemeral-multiarch-prebuilt/templates/runner-configs/linux-arm64-ubuntu.yaml
@@ -35,7 +35,8 @@ runner_config:
   enable_organization_runners: true
   enable_ephemeral_runners: true
   enable_job_queued_check: true
-  minimum_running_time_in_minutes: 2
+  # See linux-amd64-ubuntu.yaml for rationale; same reasoning applies here.
+  minimum_running_time_in_minutes: 30
   enable_runner_binaries_syncer: false
   disable_runner_autoupdate: true
   create_service_linked_role_spot: true


### PR DESCRIPTION
## Summary

Raise \`minimum_running_time_in_minutes\` from \`2\` → \`30\` across all three ephemeral-runner configs (\`linux-amd64-ubuntu.yaml\`, \`linux-amd64-ubuntu-xl.yaml\`, \`linux-arm64-ubuntu.yaml\`).

## Why

The scale-down Lambda runs every minute (\`scale_down_schedule_expression: cron(* * * * ? *)\`). For each runner past \`minimum_running_time_in_minutes\`, it asks GitHub's API for the per-runner \`busy\` flag and terminates the runner if that flag is \`false\`.

With the threshold at **2 minutes**, every job that runs longer than ~2 min gets evaluated 10+ times. A single stale or transient \`busy: false\` response from the GitHub API — race window between job dispatch and the runner reporting busy, API hiccup, eventual-consistency lag — triggers \`TerminateInstances\` mid-build. The runner agent's \`EXIT\` trap then self-terminates the box (\`Client.UserInitiatedShutdown\` in EC2's state). The job shows the generic **\"self-hosted runner lost communication\"** annotation on GitHub, all step logs are unrecoverable (the agent died before flush).

This fits the failure pattern across recent emqx CI:

- Multiple job types affected: \`build_slim_packages / linux (amd64|arm64)\`, \`run_test_cases / apps/emqx-*\`, \`run_test_cases / apps/emqx_bridge_*\`, \`run_test_cases / apps/emqx_opentelemetry-1_1\`, \`build_docker\`, \`static_checks\` — anything that runs ≥10 min.
- Failures cluster in the 12-17 min window.
- Retries fail at the same rate.
- The minority of failures (~9% in a recent 46-instance sample) are real spot interruptions (\`Server.SpotInstanceTermination\`); the majority show \`Client.UserInitiatedShutdown\` and have no external-caller \`TerminateInstances\` in CloudTrail beyond the runner's own role — consistent with the in-box cleanup trap firing after the Lambda's de-register-and-terminate path.

## Trade-off

A runner that registers but never picks up a job (rare: JIT registration failure, webhook delivery delay) now lingers up to 30 minutes before scale-down reclaims it instead of 2 minutes. At \`m6a.large\` / \`m6g.large\` spot pricing, that's ~5¢ of compute per orphaned runner — negligible compared to the cost of losing a whole CI run.

## Validation plan

After merge + deploy:
- Watch the next ~10 PR runs that include build_slim_packages or the long CT shards.
- Compare lost-comm failure rate before vs after (we have probe data in PR #17357 establishing the baseline rate).